### PR TITLE
Use complete path as dirbase

### DIFF
--- a/lib/mktorrent.rb
+++ b/lib/mktorrent.rb
@@ -2,6 +2,7 @@ require 'bencode'
 require 'digest/sha1'
 require 'date'
 require 'uri'
+require 'pathname'
 
 # Sample usage
 #t = Torrent.new("http://your.tracker.com")

--- a/lib/mktorrent.rb
+++ b/lib/mktorrent.rb
@@ -129,8 +129,8 @@ class Torrent
   end
 
   def add_directory(path)
-    path = Pathname.new(path)
-    @dirbase = File.dirname(path) unless path.relative?
+    pathname = Pathname.new(path)
+    @dirbase = path unless pathname.relative?
     add_directory_to_torrent(path)
   end
 

--- a/lib/mktorrent.rb
+++ b/lib/mktorrent.rb
@@ -9,7 +9,7 @@ require 'uri'
 #t.write_torrent("~/Downloads/mytorrent.torrent")
 
 class Torrent
-  attr_reader :torrent_file, :infohash
+  attr_reader :torrent_file, :infohash, :dirbase
   attr_accessor :info, :filehashes, :piecelength, :files, :defaultdir, :tracker, :size, :privacy, :webseed, :tracker_list
 
   # optionally initialize filename

--- a/test/mktorrent_test.rb
+++ b/test/mktorrent_test.rb
@@ -60,6 +60,7 @@ class MktorrentTest < Minitest::Test
   def test_add_directory_uses_relative_paths
     assert [ VALIDFILEPATH, VALIDFILE2PATH ].each { |p| p.start_with?(VALIDPATH) }
     @torrent.add_directory(VALIDPATH)
+    assert_equal @torrent.dirbase, VALIDPATH
     assert @torrent.files.each { |f| ! f[:path].join('/').start_with?(File.basename(File.dirname(VALIDPATH))) }
   end
 


### PR DESCRIPTION
When using `add_directory` the directory is still included as part of the torrent. With uTorrent's functionality you add a directory and only the directory contents are included in the torrent. This new functionality matches uTorrent's functionality (which was my original intention with the feature). 
