### PR TITLE
A few improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,30 +3,27 @@ PATH
   specs:
     mktorrent (1.7.0)
       bencode (~> 0.8)
-      rake (~> 10.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ansi (1.5.0)
     bencode (0.8.2)
-    builder (3.2.2)
-    coderay (1.1.0)
-    method_source (0.8.2)
-    minitest (5.8.0)
-    minitest-reporters (1.1.0)
+    builder (3.2.3)
+    coderay (1.1.2)
+    method_source (0.9.0)
+    minitest (5.11.3)
+    minitest-reporters (1.3.1)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    pry (0.10.1)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (10.4.2)
-    ruby-progressbar (1.7.5)
+      method_source (~> 0.9.0)
+    rake (12.3.1)
+    ruby-progressbar (1.9.0)
     rubygems-tasks (0.2.4)
-    slop (3.6.0)
 
 PLATFORMS
   ruby
@@ -36,7 +33,8 @@ DEPENDENCIES
   minitest-reporters (~> 1.0)
   mktorrent!
   pry
+  rake
   rubygems-tasks (= 0.2.4)
 
 BUNDLED WITH
-   1.10.6
+   1.16.2

--- a/mktorrent.gemspec
+++ b/mktorrent.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
 
   # Gems
   spec.add_dependency('bencode', '~> 0.8')
-  spec.add_dependency('rake', '~> 10.1')
+  spec.add_development_dependency('rake')
+  spec.add_development_dependency('shellwords')
   spec.add_development_dependency('pry')
   spec.add_development_dependency('minitest', '~> 5.0')
   spec.add_development_dependency('minitest-reporters', '~> 1.0')

--- a/mktorrent.gemspec
+++ b/mktorrent.gemspec
@@ -10,12 +10,11 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.files = Dir['lib/*.rb']
   spec.test_files = Dir['test/*.rb']
-  spec.version = '1.7.0'
+  spec.version = '1.8.0'
 
   # Gems
   spec.add_dependency('bencode', '~> 0.8')
   spec.add_development_dependency('rake')
-  spec.add_development_dependency('shellwords')
   spec.add_development_dependency('pry')
   spec.add_development_dependency('minitest', '~> 5.0')
   spec.add_development_dependency('minitest-reporters', '~> 1.0')

--- a/test/mktorrent_test.rb
+++ b/test/mktorrent_test.rb
@@ -4,6 +4,7 @@ class MktorrentTest < Minitest::Test
 
   def setup
     @torrent = Torrent.new(TRACKER)
+    @torrent2 = Torrent.new(TRACKER)
     # Lol. This is pretty bad :)
     fail "Could not find #{VALIDFILEPATH}" unless File.exist? VALIDFILEPATH
     fail "Could not find #{VALIDFILE2PATH}" unless File.exist? VALIDFILE2PATH
@@ -83,5 +84,12 @@ class MktorrentTest < Minitest::Test
     assert_raises(ArgumentError) {
       @torrent.set_webseed('uheoatnhuetano')
     }
+  end
+
+  def test_torrent2_equality
+     assert_equal @torrent, @torrent2
+     @torrent2.tracker = 'http://example.com'
+     assert @torrent == @torrent2, 'info hash should still match, so torrent == torrent2'
+     assert !@torrent.eql?(@torrent2), 'announce uri changed, so torrent ! eql? torrent2'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'minitest/autorun'
 require 'minitest/unit'
 require 'minitest/reporters'
+require 'shellwords'
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'mktorrent')
 Dir.glob('test/support/*.rb').each { |r| load r }


### PR DESCRIPTION
1. Adds the ability to use blocks within the initializers for instances.

2. Adds Torrent.from_file to create an object based on the contents of a file

3. Removes version constraint on Rake and makes it a development dependency rather than an install dependency (this breaks when it interacts with other gems that rely on rake, it's not needed at run-time).

4. Adds the comparable interface, so you can tell if one torrent is equal to another, either because the info segment is the same (via == ) (they have the same files) or because the whole torrent hash is the same (via eql?) (they share tracker information as well).

5. Removes nil.empty? conflicts for when you are not running this against rails environments